### PR TITLE
fix network restart on EL8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-
+* Fix network restart by using a more common value for PATH env variable 
 
 ## Release [1.0.0] - 27.02.2020
 Initial release

--- a/manifests/network_restart.pp
+++ b/manifests/network_restart.pp
@@ -14,7 +14,7 @@ define foreman_network::network_restart (
   if $mange_network_interface_restart {
     exec { "network_restart_${interface}":
       command     => "ifdown ${interface} --force ; ifup ${interface}",
-      path        => '/sbin',
+      path        => '/bin:/usr/bin:/sbin:/usr/sbin',
       refreshonly => true,
     }
   }


### PR DESCRIPTION
When using this module on Rocky Linux 8.6, an attempt to restart the network will fail:

```
Notice: /Stage[main]/Foreman_network/Foreman_network::Network_restart[ens3]/Exec[network_restart_ens3]/returns: /sbin/ifdown: line 28: nmcli: command not found
Notice: /Stage[main]/Foreman_network/Foreman_network::Network_restart[ens3]/Exec[network_restart_ens3]/returns: /sbin/ifdown: line 11: cat: command not found
Notice: /Stage[main]/Foreman_network/Foreman_network::Network_restart[ens3]/Exec[network_restart_ens3]/returns: /sbin/ifup: line 28: nmcli: command not found
Notice: /Stage[main]/Foreman_network/Foreman_network::Network_restart[ens3]/Exec[network_restart_ens3]/returns: /sbin/ifup: line 11: cat: command not found
```

Some commands cannot be found, because they live outside of `/sbin`, which is the only available path.